### PR TITLE
Fixed: correct publication type for phdthesis

### DIFF
--- a/academic/cli.py
+++ b/academic/cli.py
@@ -36,8 +36,8 @@ PUB_TYPES = {
     'phdthesis': 7,
     'proceedings': 0,
     'techreport': 4,
-    'patent': 8,
-    'unpublished': 3
+    'unpublished': 3,
+    'patent': 8
 }
 
 

--- a/academic/cli.py
+++ b/academic/cli.py
@@ -33,7 +33,7 @@ PUB_TYPES = {
     'manual': 4,
     'mastersthesis': 4,
     'misc': 0,
-    'phdthesis': 4,
+    'phdthesis': 7,
     'proceedings': 0,
     'techreport': 4,
     'unpublished': 3

--- a/academic/cli.py
+++ b/academic/cli.py
@@ -31,11 +31,12 @@ PUB_TYPES = {
     'incollection': 6,
     'inproceedings': 1,
     'manual': 4,
-    'mastersthesis': 4,
+    'mastersthesis': 7,
     'misc': 0,
     'phdthesis': 7,
     'proceedings': 0,
     'techreport': 4,
+    'patent': 8,
     'unpublished': 3
 }
 


### PR DESCRIPTION
In academic-hugo:archetypes/publication/index.md we can see that the appropriate index for a thesis is 7.