### PR TITLE
streamline bibtex import

### DIFF
--- a/academic/cli.py
+++ b/academic/cli.py
@@ -125,12 +125,18 @@ def parse_bibtex_entry(entry, pub_dir='publication', featured=False, overwrite=F
     # Prepare YAML front matter for Markdown file.
     frontmatter = ['---']
     frontmatter.append(f'title: "{clean_bibtex_str(entry["title"])}"')
-    if 'month' in entry:
-        frontmatter.append(f"date: {entry['year']}-{month2number(entry['month'])}-01")
+    if 'date' in entry:
+        frontmatter.append(f"date: {entry['date']}")
+        frontmatter.append(f"publishDate: {entry['date'].split('/')[0]}") # take the first date of a range
     else:
-        frontmatter.append(f"date: {entry['year']}-01-01")
+        if 'month' in entry:
+            frontmatter.append(f"date: {entry['year']}-{month2number(entry['month'])}-01")
+            frontmatter.append(f"publishDate: {entry['year']}-{month2number(entry['month'])}-01")
+        else:
+            frontmatter.append(f"date: {entry['year']}-01-01")
+            frontmatter.append(f"publishDate: {entry['year']}-01-01")
 
-    frontmatter.append(f"publishDate: {timestamp}")
+    #frontmatter.append(f"publishDate: {timestamp}") # this makes all publications pubished at the same date!
 
     authors = None
     if 'author' in entry:


### PR DESCRIPTION
I am using hugo academic to build a website for a large team that spans several organisations. The publications of this team are collected in a central bibtex file, which is large. An import with the present version of the academic admin tool still requires considerable manual work per publication:
* copying the generated *.bib file into cite.bib (required to activate the citation button)
* when the bibtex file contains an `abstract` entry this is included in the generated bib-file, which is generally not what users want that click the `cite` button.
* adding the `projects` identifier in the markdown file of the publication to link this publication to specific projects

With this pull request the manual work per publication is reduced to a minimum, regarding the bibtex-file as the single source of information.
* per publication a file cite.bib is generated
* the `projects` identifiers are auto-generated from corresponding entries in the central bibtex file. These `projects` entries can include several project identifier strings (without the dashes) separated by white space.
* The entries `abstract` and `projects` are removed from the file cite.bib that is generated per publication.

The only remaining work that needs to be done is to copy the PDF of the publications into the generated folders.