### PR TITLE
now saving the bib to `cite.bib` -- as required since Academic 4.4

### DIFF
--- a/academic/cli.py
+++ b/academic/cli.py
@@ -103,7 +103,7 @@ def parse_bibtex_entry(entry, pub_dir='publication', featured=False, overwrite=F
 
     bundle_path = f"content/{pub_dir}/{slugify(entry['ID'])}"
     markdown_path = os.path.join(bundle_path, 'index.md')
-    cite_path = os.path.join(bundle_path, f"{slugify(entry['ID'])}.bib")
+    cite_path = os.path.join(bundle_path, f"cite.bib")
     date = datetime.utcnow()
     timestamp = date.isoformat('T') + 'Z'  # RFC 3339 timestamp.
 

--- a/academic/cli.py
+++ b/academic/cli.py
@@ -103,7 +103,7 @@ def parse_bibtex_entry(entry, pub_dir='publication', featured=False, overwrite=F
 
     bundle_path = f"content/{pub_dir}/{slugify(entry['ID'])}"
     markdown_path = os.path.join(bundle_path, 'index.md')
-    cite_path = os.path.join(bundle_path, f"cite.bib")
+    cite_path = os.path.join(bundle_path, 'cite.bib')
     date = datetime.utcnow()
     timestamp = date.isoformat('T') + 'Z'  # RFC 3339 timestamp.
 


### PR DESCRIPTION
the current version saves the bib with the name of the publication folder

since Academic 4.4, a cite button is only created for a `cite.bib` 

see here: 

https://sourcethemes.com/academic/updates/v4.4.0/#breaking-changes