### PR TITLE
Fix bibtex patent type by slightly correcting bibtex parser config

### DIFF
--- a/academic/cli.py
+++ b/academic/cli.py
@@ -92,6 +92,7 @@ def import_bibtex(bibtex, pub_dir='publication', featured=False, overwrite=False
     with open(bibtex, 'r', encoding='utf-8') as bibtex_file:
         parser = BibTexParser(common_strings=True)
         parser.customization = convert_to_unicode
+        parser.ignore_nonstandard_types = False
         bib_database = bibtexparser.load(bibtex_file, parser=parser)
         for entry in bib_database.entries:
             parse_bibtex_entry(entry, pub_dir=pub_dir, featured=featured, overwrite=overwrite, normalize=normalize)


### PR DESCRIPTION
Academic is not able to handle patent type bib entries.

The bibtex parser used by default skips through the patent bib entry because it is not a standard type. Fixed the issue 'Entry type patent not standard. Not considered.' by setting the configuration to consider even the non standard type.