### PR TITLE
:sparkles: Add Docker support; Use FM parser w/ ruamel.yaml

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 toml = "*"
 requests = "*"
 bibtexparser = "==1.1.0"
+ruamel.yaml = ">=0.16.0"
 
 [dev-packages]
 pytest = "*"

--- a/academic/cli.py
+++ b/academic/cli.py
@@ -12,6 +12,9 @@ import logging
 from datetime import datetime
 from academic import __version__ as version
 from academic.import_assets import import_assets
+from academic.import_bibtex import import_bibtex
+from academic import utils
+
 
 import bibtexparser
 from bibtexparser.bparser import BibTexParser
@@ -38,7 +41,11 @@ PUB_TYPES = {
 }
 
 # Initialise logger.
-logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", level=logging.WARNING, datefmt="%I:%M:%S%p")
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s: %(message)s",
+    level=logging.WARNING,
+    datefmt="%I:%M:%S%p",
+)
 log = logging.getLogger(__name__)
 
 
@@ -55,14 +62,21 @@ def parse_args(args):
 
     # Initialise command parser.
     parser = argparse.ArgumentParser(
-        description=f"Academic Admin Tool v{version}\nhttps://sourcethemes.com/academic/", formatter_class=RawTextHelpFormatter
+        description=f"Academic Admin Tool v{version}\nhttps://sourcethemes.com/academic/",
+        formatter_class=RawTextHelpFormatter,
     )
     subparsers = parser.add_subparsers(help="Sub-commands", dest="command")
 
     # Sub-parser for import command.
     parser_a = subparsers.add_parser("import", help="Import data into Academic")
-    parser_a.add_argument("--assets", action="store_true", help="Import third-party JS and CSS for generating an offline site")
-    parser_a.add_argument("--bibtex", required=False, type=str, help="File path to your BibTeX file")
+    parser_a.add_argument(
+        "--assets",
+        action="store_true",
+        help="Import third-party JS and CSS for generating an offline site",
+    )
+    parser_a.add_argument(
+        "--bibtex", required=False, type=str, help="File path to your BibTeX file"
+    )
     parser_a.add_argument(
         "--publication-dir",
         required=False,
@@ -70,11 +84,27 @@ def parse_args(args):
         default="publication",
         help="Directory that your publications are stored in (default `publication`)",
     )
-    parser_a.add_argument("--featured", action="store_true", help="Flag publications as featured")
-    parser_a.add_argument("--overwrite", action="store_true", help="Overwrite existing publications")
-    parser_a.add_argument("--normalize", action="store_true", help="Normalize each keyword to lowercase with uppercase first letter")
-    parser_a.add_argument("-v", "--verbose", action="store_true", required=False, help="Verbose mode")
-    parser_a.add_argument("-dr", "--dry-run", action="store_true", required=False, help="Perform a dry run (Bibtex only)")
+    parser_a.add_argument(
+        "--featured", action="store_true", help="Flag publications as featured"
+    )
+    parser_a.add_argument(
+        "--overwrite", action="store_true", help="Overwrite existing publications"
+    )
+    parser_a.add_argument(
+        "--normalize",
+        action="store_true",
+        help="Normalize each keyword to lowercase with uppercase first letter",
+    )
+    parser_a.add_argument(
+        "-v", "--verbose", action="store_true", required=False, help="Verbose mode"
+    )
+    parser_a.add_argument(
+        "-dr",
+        "--dry-run",
+        action="store_true",
+        required=False,
+        help="Perform a dry run (Bibtex only)",
+    )
 
     known_args, unknown = parser.parse_known_args(args)
 
@@ -85,10 +115,9 @@ def parse_args(args):
 
     # If no known arguments, wrap Hugo command.
     elif known_args is None and unknown:
-        cmd = []
-        cmd.append("hugo")
+        cmd = utils.hugo_in_docker_or_local()
         if args:
-            cmd.append(args)
+            cmd = " ".join([cmd, args])
         subprocess.call(cmd)
     else:
         # The command has been recognised, proceed to parse it.
@@ -108,200 +137,6 @@ def parse_args(args):
                 normalize=known_args.normalize,
                 dry_run=known_args.dry_run,
             )
-
-
-def import_bibtex(bibtex, pub_dir="publication", featured=False, overwrite=False, normalize=False, dry_run=False):
-    """Import publications from BibTeX file"""
-
-    # Check BibTeX file exists.
-    if not Path(bibtex).is_file():
-        err = "Please check the path to your BibTeX file and re-run"
-        log.error(err)
-        raise AcademicError(err)
-
-    # Load BibTeX file for parsing.
-    with open(bibtex, "r", encoding="utf-8") as bibtex_file:
-        parser = BibTexParser(common_strings=True)
-        parser.customization = convert_to_unicode
-        parser.ignore_nonstandard_types = False
-        bib_database = bibtexparser.load(bibtex_file, parser=parser)
-        for entry in bib_database.entries:
-            parse_bibtex_entry(entry, pub_dir=pub_dir, featured=featured, overwrite=overwrite, normalize=normalize, dry_run=dry_run)
-
-
-def parse_bibtex_entry(entry, pub_dir="publication", featured=False, overwrite=False, normalize=False, dry_run=False):
-    """Parse a bibtex entry and generate corresponding publication bundle"""
-    log.info(f"Parsing entry {entry['ID']}")
-
-    bundle_path = f"content/{pub_dir}/{slugify(entry['ID'])}"
-    markdown_path = os.path.join(bundle_path, "index.md")
-    cite_path = os.path.join(bundle_path, "cite.bib")
-    date = datetime.utcnow()
-    timestamp = date.isoformat("T") + "Z"  # RFC 3339 timestamp.
-
-    # Do not overwrite publication bundle if it already exists.
-    if not overwrite and os.path.isdir(bundle_path):
-        log.warning(f"Skipping creation of {bundle_path} as it already exists. " f"To overwrite, add the `--overwrite` argument.")
-        return
-
-    # Create bundle dir.
-    log.info(f"Creating folder {bundle_path}")
-    if not dry_run:
-        Path(bundle_path).mkdir(parents=True, exist_ok=True)
-
-    # Save citation file.
-    log.info(f"Saving citation to {cite_path}")
-    db = BibDatabase()
-    db.entries = [entry]
-    writer = BibTexWriter()
-    if not dry_run:
-        with open(cite_path, "w", encoding="utf-8") as f:
-            f.write(writer.write(db))
-
-    # Prepare YAML front matter for Markdown file.
-    frontmatter = ["---"]
-    frontmatter.append(f'title: "{clean_bibtex_str(entry["title"])}"')
-    year = ""
-    month = "01"
-    day = "01"
-    if "date" in entry:
-        dateparts = entry["date"].split("-")
-        if len(dateparts) == 3:
-            year, month, day = dateparts[0], dateparts[1], dateparts[2]
-        elif len(dateparts) == 2:
-            year, month = dateparts[0], dateparts[1]
-        elif len(dateparts) == 1:
-            year = dateparts[0]
-    if "month" in entry and month == "01":
-        month = month2number(entry["month"])
-    if "year" in entry and year == "":
-        year = entry["year"]
-    if len(year) == 0:
-        log.error(f'Invalid date for entry `{entry["ID"]}`.')
-    frontmatter.append(f"date: {year}-{month}-{day}")
-
-    frontmatter.append(f"publishDate: {timestamp}")
-
-    authors = None
-    if "author" in entry:
-        authors = entry["author"]
-    elif "editor" in entry:
-        authors = entry["editor"]
-    if authors:
-        authors = clean_bibtex_authors([i.strip() for i in authors.replace("\n", " ").split(" and ")])
-        frontmatter.append(f"authors: [{', '.join(authors)}]")
-
-    frontmatter.append(f'publication_types: ["{PUB_TYPES.get(entry["ENTRYTYPE"], 0)}"]')
-
-    if "abstract" in entry:
-        frontmatter.append(f'abstract: "{clean_bibtex_str(entry["abstract"])}"')
-    else:
-        frontmatter.append('abstract: ""')
-
-    frontmatter.append(f"featured: {str(featured).lower()}")
-
-    # Publication name.
-    if "booktitle" in entry:
-        frontmatter.append(f'publication: "*{clean_bibtex_str(entry["booktitle"])}*"')
-    elif "journal" in entry:
-        frontmatter.append(f'publication: "*{clean_bibtex_str(entry["journal"])}*"')
-    elif "publisher" in entry:
-        frontmatter.append(f'publication: "*{clean_bibtex_str(entry["publisher"])}*"')
-    else:
-        frontmatter.append('publication: ""')
-
-    if "keywords" in entry:
-        frontmatter.append(f'tags: [{clean_bibtex_tags(entry["keywords"], normalize)}]')
-
-    if "url" in entry:
-        frontmatter.append(f'url_pdf: "{clean_bibtex_str(entry["url"])}"')
-
-    if "doi" in entry:
-        frontmatter.append(f'doi: "{entry["doi"]}"')
-
-    frontmatter.append("---\n\n")
-
-    # Save Markdown file.
-    try:
-        log.info(f"Saving Markdown to '{markdown_path}'")
-        if not dry_run:
-            with open(markdown_path, "w", encoding="utf-8") as f:
-                f.write("\n".join(frontmatter))
-    except IOError:
-        log.error("Could not save file.")
-
-
-def slugify(s, lower=True):
-    bad_symbols = (".", "_", ":")  # Symbols to replace with hyphen delimiter.
-    delimiter = "-"
-    good_symbols = (delimiter,)  # Symbols to keep.
-    for r in bad_symbols:
-        s = s.replace(r, delimiter)
-
-    s = re.sub(r"(\D+)(\d+)", r"\1\-\2", s)  # Delimit non-number, number.
-    s = re.sub(r"(\d+)(\D+)", r"\1\-\2", s)  # Delimit number, non-number.
-    s = re.sub(r"((?<=[a-z])[A-Z]|(?<!\A)[A-Z](?=[a-z]))", r"\-\1", s)  # Delimit camelcase.
-    s = "".join(c for c in s if c.isalnum() or c in good_symbols).strip()  # Strip non-alphanumeric and non-hyphen.
-    s = re.sub("-{2,}", "-", s)  # Remove consecutive hyphens.
-
-    if lower:
-        s = s.lower()
-    return s
-
-
-def clean_bibtex_authors(author_str):
-    """Convert author names to `firstname(s) lastname` format."""
-    authors = []
-    for s in author_str:
-        s = s.strip()
-        if len(s) < 1:
-            continue
-        if "," in s:
-            split_names = s.split(",", 1)
-            last_name = split_names[0].strip()
-            first_names = [i.strip() for i in split_names[1].split()]
-        else:
-            split_names = s.split()
-            last_name = split_names.pop()
-            first_names = [i.replace(".", ". ").strip() for i in split_names]
-        if last_name in ["jnr", "jr", "junior"]:
-            last_name = first_names.pop()
-        for item in first_names:
-            if item in ["ben", "van", "der", "de", "la", "le"]:
-                last_name = first_names.pop() + " " + last_name
-        authors.append(f'"{" ".join(first_names)} {last_name}"')
-    return authors
-
-
-def clean_bibtex_str(s):
-    """Clean BibTeX string and escape TOML special characters"""
-    s = s.replace("\\", "")
-    s = s.replace('"', '\\"')
-    s = s.replace("{", "").replace("}", "")
-    s = s.replace("\t", " ").replace("\n", " ").replace("\r", "")
-    return s
-
-
-def clean_bibtex_tags(s, normalize=False):
-    """Clean BibTeX keywords and convert to TOML tags"""
-    tags = clean_bibtex_str(s).split(",")
-    tags = [f'"{tag.strip()}"' for tag in tags]
-    if normalize:
-        tags = [tag.lower().capitalize() for tag in tags]
-    tags_str = ", ".join(tags)
-    return tags_str
-
-
-def month2number(month):
-    """Convert BibTeX or BibLateX month to numeric"""
-    if len(month) <= 2:  # Assume a 1 or 2 digit numeric month has been given.
-        return month.zfill(2)
-    else:  # Assume a textual month has been given.
-        month_abbr = month.strip()[:3].title()
-        try:
-            return str(list(calendar.month_abbr).index(month_abbr)).zfill(2)
-        except ValueError:
-            raise log.error("Please update the entry with a valid month.")
 
 
 if __name__ == "__main__":

--- a/academic/editFM.py
+++ b/academic/editFM.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+yaml = YAML()
+
+
+class EditableFM:
+    def __init__(self, base_path: Path, delim: str = "---"):
+        self.base_path = Path(base_path)
+        if delim != "---":
+            raise NotImplementedError(
+                "Currently, YAML is the only supported front-matter format."
+            )
+        self.delim = delim
+
+    def load(self, file: Path):
+        self.fm = []
+        self.content = []
+
+        self.path = self.base_path / file
+
+        file = open(self.path, "r").readlines()
+
+        lineno = 0
+        delims_seen = 0
+        for line in file:
+            if line.startswith(self.delim):
+                delims_seen += 1
+            else:
+                if delims_seen < 2:
+                    self.fm.append(line)
+                else:
+                    self.content.append(line)
+
+        # Parse YAML, trying to preserve comments and whitespace
+        self.fm = yaml.load("".join(self.fm))
+
+    def dump(self):
+        assert self.path, "You need to `.load()` first."
+
+        with open(self.path, "w") as f:
+            f.write("{}\n".format(self.delim))
+            yaml.dump(self.fm, f)
+            f.write("{}\n".format(self.delim))
+            f.writelines(self.content)

--- a/academic/import_assets.py
+++ b/academic/import_assets.py
@@ -26,7 +26,8 @@ def import_assets():
     academic_filename = "themes/academic/data/academic.toml"
     if not Path(academic_filename).is_file():
         log.error(
-            "Could not detect Academic version in `themes/academic/data/academic.toml`. " "You may need to update Academic in order to use this tool."
+            "Could not detect Academic version in `themes/academic/data/academic.toml`. "
+            "You may need to update Academic in order to use this tool."
         )
         return
 
@@ -34,7 +35,9 @@ def import_assets():
     # Note that the order of assets in `assets.toml` matters since they will be concatenated in the order they appear.
     assets_filename = "themes/academic/data/assets.toml"
     if not Path(assets_filename).is_file():
-        log.error("Could not detect assets file. You may need to update Academic in order to use this tool.")
+        log.error(
+            "Could not detect assets file. You may need to update Academic in order to use this tool."
+        )
         return
 
     # Create output dirs if necessary
@@ -49,7 +52,9 @@ def import_assets():
         # Parse JS assets
         js_files = []
         for i, j in parsed_toml["js"].items():
-            url = j["url"].replace("%s", j["version"], 1)  # Replace placeholder with asset version.
+            url = j["url"].replace(
+                "%s", j["version"], 1
+            )  # Replace placeholder with asset version.
             filename = os.path.basename(urlparse(url).path)
             filepath = os.path.join(d, filename)
             js_files.append(filepath)
@@ -63,14 +68,18 @@ def import_assets():
         # Parse CSS assets
         css_files = []
         for i, j in parsed_toml["css"].items():
-            url = j["url"].replace("%s", j["version"], 1)  # Replace placeholder with asset version.
+            url = j["url"].replace(
+                "%s", j["version"], 1
+            )  # Replace placeholder with asset version.
 
             # Special case for highlight.js style
             if i == "highlight":
                 # Assume user is using a light theme.
                 # TODO: Set to .Site.Params.highlight_style if set, or dracula if using a dark theme.
                 hl_theme = "github"
-                url = url.replace("%s", hl_theme)  # Replace the second placeholder with style name.
+                url = url.replace(
+                    "%s", hl_theme
+                )  # Replace the second placeholder with style name.
             filename = os.path.basename(urlparse(url).path)
             filepath = os.path.join(d, filename)
             css_files.append(filepath)

--- a/academic/import_bibtex.py
+++ b/academic/import_bibtex.py
@@ -1,0 +1,277 @@
+import subprocess
+import os
+import re
+import time
+from pathlib import Path
+import calendar
+from datetime import datetime
+from academic import utils
+from academic.editFM import EditableFM
+
+import bibtexparser
+from bibtexparser.bparser import BibTexParser
+from bibtexparser.bwriter import BibTexWriter
+from bibtexparser.bibdatabase import BibDatabase
+from bibtexparser.customization import convert_to_unicode
+
+
+# Map BibTeX to Academic publication types.
+PUB_TYPES = {
+    "article": 2,
+    "book": 5,
+    "inbook": 6,
+    "incollection": 6,
+    "inproceedings": 1,
+    "manual": 4,
+    "mastersthesis": 7,
+    "misc": 0,
+    "phdthesis": 7,
+    "proceedings": 0,
+    "techreport": 4,
+    "unpublished": 3,
+    "patent": 8,
+}
+
+
+def import_bibtex(
+    bibtex,
+    pub_dir="publication",
+    featured=False,
+    overwrite=False,
+    normalize=False,
+    dry_run=False,
+):
+    """Import publications from BibTeX file"""
+    from academic.cli import log, AcademicError
+
+    # Check BibTeX file exists.
+    if not Path(bibtex).is_file():
+        err = "Please check the path to your BibTeX file and re-run"
+        log.error(err)
+        raise AcademicError(err)
+
+    # Load BibTeX file for parsing.
+    with open(bibtex, "r", encoding="utf-8") as bibtex_file:
+        parser = BibTexParser(common_strings=True)
+        parser.customization = convert_to_unicode
+        parser.ignore_nonstandard_types = False
+        bib_database = bibtexparser.load(bibtex_file, parser=parser)
+        for entry in bib_database.entries:
+            parse_bibtex_entry(
+                entry,
+                pub_dir=pub_dir,
+                featured=featured,
+                overwrite=overwrite,
+                normalize=normalize,
+                dry_run=dry_run,
+            )
+
+
+def parse_bibtex_entry(
+    entry,
+    pub_dir="publication",
+    featured=False,
+    overwrite=False,
+    normalize=False,
+    dry_run=False,
+):
+    """Parse a bibtex entry and generate corresponding publication bundle"""
+    from academic.cli import log
+
+    log.info(f"Parsing entry {entry['ID']}")
+
+    bundle_path = f"content/{pub_dir}/{slugify(entry['ID'])}"
+    markdown_path = os.path.join(bundle_path, "index.md")
+    cite_path = os.path.join(bundle_path, "cite.bib")
+    date = datetime.utcnow()
+    timestamp = date.isoformat("T") + "Z"  # RFC 3339 timestamp.
+
+    # Do not overwrite publication bundle if it already exists.
+    if not overwrite and os.path.isdir(bundle_path):
+        log.warning(
+            f"Skipping creation of {bundle_path} as it already exists. "
+            f"To overwrite, add the `--overwrite` argument."
+        )
+        return
+
+    # Create bundle dir.
+    log.info(f"Creating folder {bundle_path}")
+    if not dry_run:
+        Path(bundle_path).mkdir(parents=True, exist_ok=True)
+
+    # Save citation file.
+    log.info(f"Saving citation to {cite_path}")
+    db = BibDatabase()
+    db.entries = [entry]
+    writer = BibTexWriter()
+    if not dry_run:
+        with open(cite_path, "w", encoding="utf-8") as f:
+            f.write(writer.write(db))
+
+    # Prepare YAML front matter for Markdown file.
+    hugo = utils.hugo_in_docker_or_local()
+    subprocess.call(
+        f"{hugo} new {markdown_path} --kind publication",
+        shell=True
+    )
+    if "docker-compose" in hugo:
+        time.sleep(2)
+
+    page = EditableFM(bundle_path)
+    page.load("index.md")
+
+    page.fm["title"] = clean_bibtex_str(entry["title"])
+
+    year, month, day = "", "01", "01"
+    if "date" in entry:
+        dateparts = entry["date"].split("-")
+        if len(dateparts) == 3:
+            year, month, day = dateparts[0], dateparts[1], dateparts[2]
+        elif len(dateparts) == 2:
+            year, month = dateparts[0], dateparts[1]
+        elif len(dateparts) == 1:
+            year = dateparts[0]
+    if "month" in entry and month == "01":
+        month = month2number(entry["month"])
+    if "year" in entry and year == "":
+        year = entry["year"]
+    if len(year) == 0:
+        log.error(f'Invalid date for entry `{entry["ID"]}`.')
+
+    page.fm["date"] = "-".join([year, month, day])
+    page.fm["publishDate"] = timestamp
+
+    authors = None
+    if "author" in entry:
+        authors = entry["author"]
+    elif "editor" in entry:
+        authors = entry["editor"]
+
+    if authors:
+        authors = clean_bibtex_authors(
+            [i.strip() for i in authors.replace("\n", " ").split(" and ")]
+        )
+        page.fm["authors"] = authors
+
+    page.fm["publication_types"] = [PUB_TYPES.get(entry["ENTRYTYPE"], "0")]
+
+    if "abstract" in entry:
+        page.fm["abstract"] = clean_bibtex_str(entry["abstract"])
+    else:
+        page.fm["abstract"] = ""
+
+    page.fm["featured"] = featured
+
+    # Publication name.
+    if "booktitle" in entry:
+        publication = "*" + clean_bibtex_str(entry["booktitle"]) + "*"
+    elif "journal" in entry:
+        publication = "*" + clean_bibtex_str(entry["journal"]) + "*"
+    elif "publisher" in entry:
+        publication = "*" + clean_bibtex_str(entry["publisher"]) + "*"
+    else:
+        publication = ""
+    page.fm["publication"] = publication
+
+    if "keywords" in entry:
+        page.fm["tags"] = clean_bibtex_tags(entry["keywords"], normalize)
+
+    if "url" in entry:
+        page.fm["url_pdf"] = clean_bibtex_str(entry["url"])
+
+    if "doi" in entry:
+        page.fm["doi"] = clean_bibtex_str(entry["doi"])
+
+    # Save Markdown file.
+    try:
+        log.info(f"Saving Markdown to '{markdown_path}'")
+        if not dry_run:
+            page.dump()
+    except IOError:
+        log.error("Could not save file.")
+
+
+def slugify(s, lower=True):
+    bad_symbols = (".", "_", ":")  # Symbols to replace with hyphen delimiter.
+    delimiter = "-"
+    good_symbols = (delimiter,)  # Symbols to keep.
+    for r in bad_symbols:
+        s = s.replace(r, delimiter)
+
+    s = re.sub(r"(\D+)(\d+)", r"\1\-\2", s)  # Delimit non-number, number.
+    s = re.sub(r"(\d+)(\D+)", r"\1\-\2", s)  # Delimit number, non-number.
+    s = re.sub(
+        r"((?<=[a-z])[A-Z]|(?<!\A)[A-Z](?=[a-z]))", r"\-\1", s
+    )  # Delimit camelcase.
+    s = "".join(
+        c for c in s if c.isalnum() or c in good_symbols
+    ).strip()  # Strip non-alphanumeric and non-hyphen.
+    s = re.sub("-{2,}", "-", s)  # Remove consecutive hyphens.
+
+    if lower:
+        s = s.lower()
+    return s
+
+
+def clean_bibtex_authors(author_str):
+    """Convert author names to `firstname(s) lastname` format."""
+    authors = []
+    for s in author_str:
+        s = s.strip()
+        if len(s) < 1:
+            continue
+
+        if "," in s:
+            split_names = s.split(",", 1)
+            last_name = split_names[0].strip()
+            first_names = [i.strip() for i in split_names[1].split()]
+        else:
+            split_names = s.split()
+            last_name = split_names.pop()
+            first_names = [i.replace(".", ". ").strip() for i in split_names]
+
+        if last_name in ["jnr", "jr", "junior"]:
+            last_name = first_names.pop()
+            
+        for item in first_names:
+            if item in ["ben", "van", "der", "de", "la", "le"]:
+                last_name = first_names.pop() + " " + last_name
+
+        authors.append(" ".join(first_names) + " " + last_name)
+
+    return authors
+
+
+def clean_bibtex_str(s):
+    """Clean BibTeX string and escape TOML special characters"""
+    s = s.replace("\\", "")
+    s = s.replace('"', '\\"')
+    s = s.replace("{", "").replace("}", "")
+    s = s.replace("\t", " ").replace("\n", " ").replace("\r", "")
+    return s
+
+
+def clean_bibtex_tags(s, normalize=False):
+    """Clean BibTeX keywords and convert to TOML tags"""
+
+    tags = clean_bibtex_str(s).split(",")
+    tags = [f'"{tag.strip()}"' for tag in tags]
+
+    if normalize:
+        tags = [tag.lower().capitalize() for tag in tags]
+
+    return tags
+
+
+def month2number(month):
+    """Convert BibTeX or BibLateX month to numeric"""
+    from academic.cli import log
+
+    if len(month) <= 2:  # Assume a 1 or 2 digit numeric month has been given.
+        return month.zfill(2)
+    else:  # Assume a textual month has been given.
+        month_abbr = month.strip()[:3].title()
+        try:
+            return str(list(calendar.month_abbr).index(month_abbr)).zfill(2)
+        except ValueError:
+            raise log.error("Please update the entry with a valid month.")

--- a/academic/utils.py
+++ b/academic/utils.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def hugo_in_docker_or_local():
+    """Checks if there's a `docker-compose.yml` in local directory. If so, prefer that
+    to a local hugo installation.
+    """
+    if Path().glob("docker-compose.yml"):
+        hugo = "docker-compose run hugo"
+    else:
+        hugo = ""
+
+    return " ".join([hugo, "hugo"])


### PR DESCRIPTION
- Adding `docker-compose` support.
- Leverage `hugo new [path] --kind publication` so changes to archetype
  are reflected.
- "Implement" (copied from personal repo) a Front-Matter parser to
  enable greater code readability and proper YAML support.
  - Add `ruamel.yaml` as a dependency for round-trip YAML parsing with
    commend support.
- Chunked `bibtex`-related code into `import_bibtex` for improved
  readability.