### PR TITLE
Specified file encoding as UTF-8

### DIFF
--- a/academic/editFM.py
+++ b/academic/editFM.py
@@ -38,7 +38,7 @@ class EditableFM:
     def dump(self):
         assert self.path, "You need to `.load()` first."
 
-        with open(self.path, "w") as f:
+        with open(self.path, "w", encoding="utf-8") as f:
             f.write("{}\n".format(self.delim))
             yaml.dump(self.fm, f)
             f.write("{}\n".format(self.delim))


### PR DESCRIPTION
When exporting a .bib file from Zotero, the default encoding seems to be UTF-8. However, it is not currently specified on the Academic script. This was causing issues when there were characters such as μ. I made a small change to the editFM.py file to specify the encoding.