### PR TITLE
Fix check for docker-compose

### DIFF
--- a/academic/utils.py
+++ b/academic/utils.py
@@ -5,7 +5,7 @@ def hugo_in_docker_or_local():
     """Checks if there's a `docker-compose.yml` in local directory. If so, prefer that
     to a local hugo installation.
     """
-    if Path().glob("docker-compose.yml"):
+    if Path("docker-compose.yml").exists():
         hugo = "docker-compose run hugo"
     else:
         hugo = ""


### PR DESCRIPTION
Path().glob("docker-compose.yml") returns a generator that is always a
true value in if conditions (even if the list that it returns is emtpy).
Fix this by using `Path("docker-compose.yml").exists()`.